### PR TITLE
Basic Kotlin Propositional Logic Methods

### DIFF
--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -9,10 +9,6 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    kotlin("test")
-}
-
 // tasks.test {
 //    useJUnitPlatform()
 // }

--- a/logic/build.gradle.kts
+++ b/logic/build.gradle.kts
@@ -2,20 +2,12 @@ plugins {
     kotlin("multiplatform") version "1.9.22"
 }
 
-group = ""
+group = "dev.lancy.propentia"
 version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
 }
-
-// tasks.test {
-//    useJUnitPlatform()
-// }
-
-// kotlin {
-//    jvmToolchain(21)
-// }
 
 kotlin {
     js(IR) {
@@ -25,7 +17,6 @@ kotlin {
         generateTypeScriptDefinitions()
     }
 
-    // No @ExperimentalJsExport dawdle.
     sourceSets {
         val jsMain by getting
         val jsTest by getting {
@@ -34,6 +25,7 @@ kotlin {
             }
         }
 
+        // No @ExperimentalJsExport dawdle.
         all {
             languageSettings.apply {
                 optIn("kotlin.js.ExperimentalJsExport")

--- a/logic/src/jsMain/kotlin/common/Utils.kt
+++ b/logic/src/jsMain/kotlin/common/Utils.kt
@@ -1,5 +1,0 @@
-package common
-
-fun Boolean?.compareBy(other: Boolean?, comparator: (Boolean, Boolean) -> Boolean): Boolean? {
-    return this?.let { lhsB -> other?.let { rhsB -> comparator(lhsB, rhsB) } }
-}

--- a/logic/src/jsMain/kotlin/prop/PBuilder.kt
+++ b/logic/src/jsMain/kotlin/prop/PBuilder.kt
@@ -1,0 +1,9 @@
+package prop
+
+import prop.PProof.Box
+
+fun newProof(init: Box.() -> Unit): Box {
+    val box = IDGen().let { Box(it.getID(), null, null, it) }
+    box.init()
+    return box
+}

--- a/logic/src/jsMain/kotlin/prop/PExamples.kt
+++ b/logic/src/jsMain/kotlin/prop/PExamples.kt
@@ -1,3 +1,25 @@
 package prop
 
-fun e1(): PProof = TODO()
+import prop.PExpr.Var
+import prop.PJust.*
+
+/** p | q |- (p -> q) -> q*/
+@JsExport
+fun e1(): PProof =
+    newProof {
+        var (impID, csqID) = Pair(0, 0)
+        val orID = appendLine(Var("p") or Var("q"), Prem)
+        appendBox {
+            impID = appendLine(Var("p") imp Var("q"), Asm)
+            val (leftID, rightID) =
+                appendParallel { left, right ->
+                    val pID = left.appendLine(Var("p"), Asm)
+                    left.appendLine(Var("q"), ImpE(impID, pID))
+
+                    val qID = right.appendLine(Var("q"), Asm)
+                    right.appendLine(Var("q"), Sta(qID))
+                }
+            csqID = appendLine(Var("q"), OrE(orID, leftID, rightID))
+        }
+        appendLine((Var("p") imp Var("q")) imp Var("q"), ImpI(impID, csqID))
+    }

--- a/logic/src/jsMain/kotlin/prop/PExamples.kt
+++ b/logic/src/jsMain/kotlin/prop/PExamples.kt
@@ -1,0 +1,3 @@
+package prop
+
+fun e1(): PProof = TODO()

--- a/logic/src/jsMain/kotlin/prop/PExpr.kt
+++ b/logic/src/jsMain/kotlin/prop/PExpr.kt
@@ -20,6 +20,14 @@ sealed class PExpr {
 
     data class Iff(val lhs: PExpr, val rhs: PExpr) : PExpr()
 
+    infix fun and(rhs: PExpr): PExpr = And(this, rhs)
+
+    infix fun or(rhs: PExpr): PExpr = Or(this, rhs)
+
+    infix fun imp(rhs: PExpr): PExpr = Imp(this, rhs)
+
+    infix fun iff(rhs: PExpr): PExpr = Iff(this, rhs)
+
     /** Is a propositional atom, top, or bottom. (Excl. negated atomics.) */
     fun isAtomic(): Boolean {
         return when (this) {

--- a/logic/src/jsMain/kotlin/prop/PExpr.kt
+++ b/logic/src/jsMain/kotlin/prop/PExpr.kt
@@ -1,7 +1,5 @@
 package prop
 
-import common.compareBy
-
 typealias VarID = String
 
 @JsExport
@@ -103,4 +101,11 @@ sealed class PExpr {
             is Iff -> lhs.eval(env).compareBy(rhs.eval(env), Boolean::equals)
         }
     }
+}
+
+fun Boolean?.compareBy(
+    other: Boolean?,
+    comparator: (Boolean, Boolean) -> Boolean,
+): Boolean? {
+    return this?.let { lhsB -> other?.let { rhsB -> comparator(lhsB, rhsB) } }
 }

--- a/logic/src/jsMain/kotlin/prop/PJust.kt
+++ b/logic/src/jsMain/kotlin/prop/PJust.kt
@@ -154,4 +154,10 @@ sealed class PJust {
         override val latexTag = tag
         override val desc = "An assumption which the proof is based upon."
     }
+
+    data class Sta(val orig: ID) : PJust() {
+        override val tag = "Sta"
+        override val latexTag = Prem.tag
+        override val desc = "A previous expression repeated for clarity."
+    }
 }

--- a/logic/src/jsMain/kotlin/prop/PJust.kt
+++ b/logic/src/jsMain/kotlin/prop/PJust.kt
@@ -2,6 +2,7 @@ package prop
 
 typealias ID = Int
 
+@JsExport
 sealed class PJust {
     // === Abstracts ===
 

--- a/logic/src/jsMain/kotlin/prop/PProof.kt
+++ b/logic/src/jsMain/kotlin/prop/PProof.kt
@@ -1,19 +1,178 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package prop
 
+import prop.PExpr.*
+import prop.PJust.*
+import kotlin.reflect.KClass
+
+@JsExport
 sealed class PProof {
+    abstract val id: Int
+    abstract val parent: Box?
+
+    abstract fun root(): Box
+
+    companion object {
+        fun new(): Box = IDGen().let { Box(it.getID(), null, null, it) }
+    }
+
     data class Box(
-        val id: Int,
-        val parent: Box?,
+        override val id: Int,
+        override val parent: Box?,
         val adj: Box?,
-        val children: MutableList<PProof> = mutableListOf(),
-    ) : PProof()
+        val idGen: IDGen,
+        var children: Array<PProof> = arrayOf(),
+    ) : PProof() {
+        override fun root(): Box {
+            var currRoot = this
+            while (currRoot.parent != null) currRoot = currRoot.parent!!
+            return currRoot
+        }
+
+        fun insertAfter(
+            id: ID,
+            newObj: PProof,
+        ) {
+            val ind = children.indexOfFirst { it.id == id }
+            if (ind == -1) throw NoSuchElementException("Item with id $id does not exist in this proof!")
+            children =
+                children.toMutableList()
+                    .apply { add(ind + 1, newObj) }
+                    .toTypedArray()
+        }
+
+        fun insertBefore(
+            id: ID,
+            newObj: PProof,
+        ) {
+            val ind = children.indexOfFirst { it.id == id }
+            if (ind == -1) throw NoSuchElementException("Item with id $id does not exist in this proof!")
+            children =
+                children.toMutableList()
+                    .apply { add(ind, newObj) }
+                    .toTypedArray()
+        }
+    }
 
     data class Line(
-        val id: Int,
-        val parent: Box,
+        override val id: Int,
+        override val parent: Box,
         val expr: PExpr,
         val just: PJust,
-    ) : PProof()
+    ) : PProof() {
+        override fun root(): Box = parent.root()
 
-    // fun availableSteps(): List<Pair<PExpr, >> TODO!!!!!
+        /** Returns natural deduction steps that can be made _before_ this line. */
+        fun availableSteps(): Array<String> {
+            val currScope = scope()
+            val availableSteps = mutableSetOf<KClass<out PJust>>()
+
+            // ImpI, NotI, TopI, IffI, EM, PC, can be used anywhere.
+            availableSteps.addAll(arrayOf(ImpI::class, NotI::class, TopI::class, IffI::class, EM::class, PC::class))
+
+            if (currScope.isNotEmpty()) {
+                // AndI, OrI, DNotI, can be used on any existing line.
+                availableSteps.addAll(arrayOf(AndI::class, OrI::class, DNotI::class))
+            }
+
+            // For matching arbitrary expressions.
+            val exprs = mutableSetOf<PExpr>()
+
+            // For matching antecedents for ImpE.
+            val ants = mutableSetOf<PExpr>()
+
+            // For matching negated consequents for MT.
+            val notCsqs = mutableSetOf<PExpr>()
+
+            // For matching expressions in double implications for IffE.
+            val iffExprs = mutableSetOf<PExpr>()
+
+            // Process eliminations, and build up data for rest.
+            currScope.forEach {
+                // Adds expression to test for not-phis. Inefficient!
+                exprs.add(it.expr)
+
+                // We can use [when] here since an expr will only be one type.
+                when (it.expr) {
+                    is And -> {
+                        // AndE can be used on any existing And.
+                        availableSteps.add(AndE::class)
+                    }
+                    is Or -> {
+                        // OrE can be used on any existing Or.
+                        availableSteps.add(OrE::class)
+                    }
+                    is Bottom -> {
+                        // BotE can be used on any existing Bottom.
+                        availableSteps.add(BotE::class)
+                    }
+                    is Not -> {
+                        // DNotE can be used on any existing double negation.
+                        if (it.expr.expr is Not) availableSteps.add(DNotE::class)
+                    }
+                    is Imp -> {
+                        // Add for matching later.
+                        ants.add(it.expr.ant)
+                        notCsqs.add(Not(it.expr.csq))
+                    }
+                    is Iff -> {
+                        // IffED can be used on any existing double implication.
+                        availableSteps.add(IffED::class)
+
+                        // Add both LHS and RHS for matching later.
+                        iffExprs.add(it.expr.lhs)
+                        iffExprs.add(it.expr.rhs)
+                    }
+                    else -> Unit
+                }
+            }
+
+            // Second iteration, check rest of rules using collected data.
+            currScope.forEach {
+                // We cannot use [when] here because these tests potentially overlap.
+                if (it.expr in ants) {
+                    // ImpE can be used on an implication and its antecedent.
+                    availableSteps.add(ImpE::class)
+                }
+
+                if (it.expr in iffExprs) {
+                    // IffE can be used on a double implication and one of its sides.
+                    availableSteps.add(IffE::class)
+                }
+
+                if (it.expr in notCsqs) {
+                    // MT can be used on an implication and the negation of its consequent.
+                    availableSteps.add(MT::class)
+                }
+
+                if (it.expr is Not && it.expr.expr in exprs) {
+                    // NotE can be used on any expression and its negation.
+                    availableSteps.add(NotE::class)
+                }
+            }
+
+            return availableSteps
+                .map { it.simpleName!! }
+                .toTypedArray()
+        }
+    }
+
+    fun scope(): Array<Line> {
+        if (parent == null) return arrayOf()
+
+        return parent!!
+            .children
+            .dropLastWhile { it != this }
+            .flatMap { if (it is Line) listOf(it) else it.scope().asIterable() }
+            .union(parent!!.scope().asIterable())
+            .toTypedArray()
+    }
+}
+
+@JsExport
+class IDGen {
+    private var currID: Int = 0
+
+    fun getID(): Int = currID++
 }


### PR DESCRIPTION
Adds [PExpr], [PJust], and [PProof], for expressions, justifications, and overall proof structures respectively.

[PExpr] comes with infixed constructors such as [imp] and helper functions such as is [isLiteral] and [isDNF]. 

Every [PJust] class or object comes with a [tag] and [latexTag] such as "E.M.", and a human readable description [desc].

[PProof] can either be a [Box] or a [Line]; traversal and indexing is based on auto-incremented integer [ID]s.